### PR TITLE
Use `Float64` for time ranges, pin to `Genie` v1.18.1

### DIFF
--- a/AlgebraicPetri-Stratification/.dockerignore
+++ b/AlgebraicPetri-Stratification/.dockerignore
@@ -1,1 +1,2 @@
 SysImage.so
+Manifest.Toml

--- a/AlgebraicPetri-Stratification/Project.toml
+++ b/AlgebraicPetri-Stratification/Project.toml
@@ -9,3 +9,4 @@ PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
 
 [compat]
 AlgebraicPetri = "0.6.3 - 0.7"
+Genie = "1.18.1"

--- a/AlgebraicPetri-Stratification/src/GrometInterop.jl
+++ b/AlgebraicPetri-Stratification/src/GrometInterop.jl
@@ -484,7 +484,7 @@ a results json file.
 """
 function run_sim(pn::LabelledReactionNet{R,C},
   conc_params::Dict{Symbol, C}, rate_params::Dict{Symbol, <:Union{R, Function}},
-  t_range::Tuple{<:Real,<:Real}, tsteps::Array{<:Real,1}) where {R,C}
+  t_range::Tuple{<:Float64,<:Float64}, tsteps::Array{<:Float64,1}) where {R,C}
   sim = vectorfield(pn)
 
   #=
@@ -523,7 +523,7 @@ function run_sim(pn::LabelledReactionNet{R,C},
 end
 
 function run_sim(pn::LabelledReactionNet{R,C}, parameters,
-                 start::Number, stop::Number, step::Number) where {R,C}
+                 start::Float64, stop::Float64, step::Float64) where {R,C}
   rates = Dict{Symbol, R}()
   concs = Dict{Symbol, C}()
 
@@ -540,7 +540,10 @@ function run_sim(pn::LabelledReactionNet{R,C}, parameters,
 end
 
 function run_sim(gromet::Dict, p::Dict)
-  run_sim(gromet2petrinet(gromet), p["parameters"], p["start"], p["stop"], p["step"])
+  start = convert(Float64, p["start"])
+  stop = convert(Float64, p["stop"])
+  step = convert(Float64, p["step"])
+  run_sim(gromet2petrinet(gromet), p["parameters"], start, stop, step)
 end
 
 """ run_sim(gfile, param_file)


### PR DESCRIPTION
Re the first: the differential equation solution library throws some errors if the time ranges aren't floating point but the initial conditions (at least as specified in the gromet we send over to simulate) are. This was surfaced in testing of gromets with `Float` initial conditions, as you provided in [this PR](https://github.com/GaloisInc/askee-august-2021-demo-model-collection/pull/4). I suspect some witchcraft involving Julia's rules for typecasting to and from `Real` and `(Int|Float)64`, but I'm not certain. At any rate, with this approach, we can simulate gromets with state variables specified as either integral or floating point values.

Re the second: `Genie` v2.0.0 switched to JSON3, which supplants native Julia `Dict` objects with `JSON3` `Object`s. This opened a can of worms that seemed easiest to close by sticking with the latest working version. Happy to discuss the merits of this if it's considered too debty.